### PR TITLE
Changed from two-image transmission to single-image transmission.

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -1,22 +1,27 @@
 const cacheBuster = require('./cache-buster')
 const { allowedToSendToChatAlready } = require('./flood-control')
-
+const Jimp = require("jimp")
 const IMAGE_URLS = ['http://haba.tko-aly.fi/kuvat/webcam1.jpg', 'http://haba.tko-aly.fi/kuvat/webcam2.jpg']
-const EIGHT_S_TO_MS = 8 * 1000
-
-const createSendPhoto = tgClient => (chatId, imageUrl) => tgClient.sendPhoto(chatId, imageUrl)
-const getCacheBuster = cacheBuster(EIGHT_S_TO_MS)
-const getImageUrls = () => IMAGE_URLS.map(url => `${url}?${getCacheBuster()}`)
 
 function createCamsCommand(tgClient) {
-    const sendPhoto = createSendPhoto(tgClient)
-
     return msg => {
         if (!allowedToSendToChatAlready(msg.chat.id)) return
-        getImageUrls().forEach(url => {
-            sendPhoto(msg.chat.id, url)
-        })
+        convertAndSend(tgClient, msg)
     }
+}
+
+function convertAndSend(tgClient, msg){
+    var canvas =  new Jimp(1920, 2160);
+    var above_pic = Jimp.read(IMAGE_URLS[0]);
+    var below_pic = Jimp.read(IMAGE_URLS[1]);
+    
+    Promise.all([canvas, above_pic, below_pic]).then(images => {
+        images[0].composite(images[1], 0, 0)
+                 .composite(images[2], 0, 1080)
+                 .resize(960, 1080)
+                 .quality(60)
+                 .getBuffer(Jimp.MIME_PNG, (error, result) => tgClient.sendPhoto(msg.chat.id, result));
+    })
 }
 
 function attachCommands(tgClient) {

--- a/flood-control.js
+++ b/flood-control.js
@@ -1,4 +1,5 @@
 const getTimestamp = () => new Date().getTime()
+const EIGHT_S_TO_MS = 8 * 1000
 const chatIdToPreviousSentTimestamp = {}
 
 function allowedToSendToChatAlready(id) {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "license": "MIT",
   "dependencies": {
     "dotenv": "4.0.0",
-    "node-telegram-bot-api": "0.27.1"
+    "node-telegram-bot-api": "0.27.1",
+    "jimp": "0.2.28"
   },
   "devDependencies": {
     "nodemon": "^1.11.0"


### PR DESCRIPTION
Changed from two-image transmission to single-image transmission.

Since the pictures have to be merged in server, telegram-client will no longer get URLs.
I believe we don't need cache-buster anymore.